### PR TITLE
Update appfilter.lua

### DIFF
--- a/luci-app-oaf/luasrc/controller/appfilter.lua
+++ b/luci-app-oaf/luasrc/controller/appfilter.lua
@@ -24,10 +24,8 @@ function get_hostname_by_mac(dst_mac)
             break
         end
         local ts, mac, ip, name, duid = ln:match("^(%d+) (%S+) (%S+) (%S+) (%S+)")
-        print(ln)
         if  dst_mac == mac then
-            print("match mac", mac, "hostname=", name);
-			fd:close()
+            fd:close()
             return name
         end
     end


### PR DESCRIPTION
delete debugging code so that it is compatible with the newest snapshot openwrt (it still require an acl to work)
这里的debug用的两个print可能会造成cgi header不正确，干掉之后才能在最新版的snapshot系统上使用