### PR TITLE
appfilter: 降低架构门槛

### DIFF
--- a/open-app-filter/Makefile
+++ b/open-app-filter/Makefile
@@ -14,6 +14,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/appfilter
   SECTION:=Derry Apps
   CATEGORY:=Derry Apps
+  PKGARCH:=all
   TITLE:=App filter userspace module
 endef
 


### PR DESCRIPTION
降低架构门槛，更方便于分享和共享。
特别是单独更新时，只需要一个有则大家都可以用。不需要请求或者再为某某机器额外编一个。大家都方便。
这个后台程序无关于架构

希望加入。