### PR TITLE
修复部分设备hostname过长,导致段错误

### DIFF
--- a/open-app-filter/src/appfilter_ubus.c
+++ b/open-app-filter/src/appfilter_ubus.c
@@ -319,7 +319,7 @@ appfilter_handle_dev_list(struct ubus_context *ctx, struct ubus_object *obj,
 
             json_object_object_add(dev_obj, "applist", app_array);
             json_object_object_add(dev_obj, "mac", json_object_new_string(node->mac));
-            char hostname[32] = {0};
+            char hostname[128] = {0};
             get_hostname_by_mac(node->mac, hostname);
             json_object_object_add(dev_obj, "ip", json_object_new_string(node->ip));
 


### PR DESCRIPTION
部分设备可能长度是32，导致hostname全部被填充，在找字符串结尾/0时找到非法内存，导致段错误.