### PR TITLE
fix a issue on 21.02

### DIFF
--- a/luci-app-oaf/luasrc/model/cbi/appfilter/appfilter.lua
+++ b/luci-app-oaf/luasrc/model/cbi/appfilter/appfilter.lua
@@ -184,12 +184,12 @@ end
 fd:close()
 
 local config_users=m.uci:get_all("appfilter.user.users")
-if config_users~=nil then
-local r=utl.split(config_users, "%s+", nil, true)
-local max = table.getn(r)
-for i=1,max,1 do
-	users:value(r[i], r[i]);
-end
+if config_users~=nil and config_users~=false then
+	local r=utl.split(config_users, "%s+", nil, true)
+	local max = table.getn(r)
+	for i=1,max,1 do
+		users:value(r[i], r[i]);
+	end
 end
 m:section(SimpleSection).template = "admin_network/user_status"
 local dir, fd


### PR DESCRIPTION
On 21.02, if no users in config file, `m.uci:get_all("appfilter.user.users")` returns `false`

should fix #136