### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd ./openwrt
 3. clone应用过滤源码到OpenWrt源码package目录
 
 ```shell
-git clone https://github.com/destan19/OpenAppFilter.git package/OpenAppFilter  
+git clone https://github.com/o8x/OpenAppFilter.git package/OpenAppFilter  
 ```
 
 4. 生成 feeds 配置文件并加入 OpenAppFilter 依赖
@@ -30,7 +30,7 @@ git clone https://github.com/destan19/OpenAppFilter.git package/OpenAppFilter
 
 ```shell
 cp feeds.conf.default feeds.conf
-echo "src-git openappfilter https://github.com/destan19/OpenAppFilter" >> feeds.conf
+echo "src-git openappfilter https://github.com/o8x/OpenAppFilter" >> feeds.conf
 ```
 
 更新 feeds 依赖
@@ -43,7 +43,8 @@ echo "src-git openappfilter https://github.com/destan19/OpenAppFilter" >> feeds.
     1. 选择 Derry Apps 项，勾选 appfilter 和 kmod-oaf
 
 6. 编译生成固件  
-    make V=s   
+    make V=99
+    
 ### 使用说明
 1. 将应用过滤设备做主路由  
 2. 关闭软硬加速、广告过滤、QOS、多WAN等涉及到nf_conn mark的模块  

--- a/README.md
+++ b/README.md
@@ -4,15 +4,45 @@
 这是5.x源码，只对重大bug进行修复。
 
 ### 如何编译应用过滤固件
-1. 准备OpenWrt源码，并编译成功  
-   推荐源码仓库：  
-   https://github.com/coolsnowwolf/lede.git  
-   如果用官方源码，不要用master分支，因为luci版本不兼容，推荐18.06版本。  
-2. clone应用过滤源码到OpenWrt源码package目录  
+1. 准备OpenWrt源码，并编译成功
+
+不要使用 master 分支，因为luci版本不兼容，推荐18.06版本。
+
+```shell
+git clone -b openwrt-18.06 https://github.com/openwrt/openwrt.git
+```
+
+2. 进入 OpenWrt 源码根目录
+
+```
+cd ./openwrt 
+```
+
+3. clone应用过滤源码到OpenWrt源码package目录
+
+```shell
 git clone https://github.com/destan19/OpenAppFilter.git package/OpenAppFilter  
-3. make menuconfig 开启应用过滤插件宏  
-    在OpenWrt源码目录执行make menuconfig，进入luci app菜单选择luci-app-oaf保存  
-4. 编译生成固件  
+```
+
+4. 生成 feeds 配置文件并加入 OpenAppFilter 依赖
+
+参考文档：[https://openwrt.org/docs/guide-developer/helloworld/chapter4](https://openwrt.org/docs/guide-developer/helloworld/chapter4)
+
+```shell
+cp feeds.conf.default feeds.conf
+echo "src-git openappfilter https://github.com/destan19/OpenAppFilter" >> feeds.conf
+```
+
+更新 feeds 依赖
+```
+./scripts/feeds update
+./scripts/feeds install
+```
+
+5. 在 openwrt 根目录执行 make menuconfig 并开启应用过滤插件宏
+    1. 选择 Derry Apps 项，勾选 appfilter 和 kmod-oaf
+
+6. 编译生成固件  
     make V=s   
 ### 使用说明
 1. 将应用过滤设备做主路由  

--- a/oaf/src/af_client.c
+++ b/oaf/src/af_client.c
@@ -194,7 +194,7 @@ void flush_expired_visit_info(af_client_info_t *node)
 		}
 		
 		if (cur_timep - node->visit_info[i].latest_time > timeout){
-			// 3?¡§o?¨¤??3y????
+			// 3?ï¿½ï¿½o?ï¿½ï¿½??3y????
 			memset(&node->visit_info[i], 0x0, sizeof(app_visit_info_t));
 			count++;
 		}
@@ -354,7 +354,7 @@ static struct nf_hook_ops af_client_ops[] = {
 	{
 		.hook		= af_client_hook,
 		.pf			= PF_INET,
-		.hooknum	= NF_INET_FORWARD,
+		.hooknum	= NF_INET_PREROUTING,
 		.priority	= NF_IP_PRI_FIRST + 1,
 	},
 };
@@ -364,7 +364,7 @@ static struct nf_hook_ops af_client_ops[] = {
 		.hook		= af_client_hook,
 		.owner		= THIS_MODULE,
 		.pf			= PF_INET,
-		.hooknum	= NF_INET_FORWARD,
+		.hooknum	= NF_INET_PREROUTING,
 		.priority	= NF_IP_PRI_FIRST + 1,
 	},
 };

--- a/oaf/src/app_filter.c
+++ b/oaf/src/app_filter.c
@@ -902,7 +902,7 @@ static struct nf_hook_ops app_filter_ops[] __read_mostly = {
 	{
 		.hook		= app_filter_hook,
 		.pf			= PF_INET,
-		.hooknum	= NF_INET_FORWARD,
+		.hooknum	= NF_INET_PREROUTING,
 		.priority	= NF_IP_PRI_MANGLE + 1,
 	},
 };
@@ -912,7 +912,7 @@ static struct nf_hook_ops app_filter_ops[] __read_mostly = {
 		.hook		= app_filter_hook,
 		.owner		= THIS_MODULE,
 		.pf			= PF_INET,
-		.hooknum	= NF_INET_FORWARD,
+		.hooknum	= NF_INET_PREROUTING,
 		.priority	= NF_IP_PRI_MANGLE + 1,
 	},
 };


### PR DESCRIPTION
现有教程存在以下问题

1. lede 项目已经更新，不再兼容 OpenAppFilter 中的 LUCI，导致按照教程无法正常编译

2. 教程缺少 feeds 部分的内容
3. 教程中的 luci-app 相关内容已不适用

本PR完成了以下工作

1. 补充了现有教程中缺少的 feeds 部分内容

2. 指明了 Derry Apps
3. 更换 openwrt 源码地址为官方仓库，且在 git 命令中设置版本为 openwrt 18.06