### PR TITLE
fix: The code in regexp.c attempts to assign the character following a backslash (\) to tmp->ch, but it should assign the current character pointed by regexp after increment, not the next one

### DIFF
--- a/oaf/src/regexp.c
+++ b/oaf/src/regexp.c
@@ -87,7 +87,7 @@ static RE* compile(char *regexp)
 				}else
 				{
 					tmp->type = CHAR;
-					tmp->ch = *(regexp + 1);
+					tmp->ch = *regexp;
 				}
 				break;
 			case '.':


### PR DESCRIPTION
This line attempts to assign the character following a backslash (\) to tmp->ch, but it should assign the current character pointed by regexp after increment, not the next one