### PR TITLE
oaf: fix work for linux 6.12

### DIFF
--- a/oaf/src/af_log.c
+++ b/oaf/src/af_log.c
@@ -59,8 +59,9 @@ static struct ctl_table oaf_table[] = {
 		.mode = 0666,
 		.proc_handler = proc_douintvec,
 	},
-	{
-	}
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0))
+	{}
+#endif
 };
 
 static struct ctl_table oaf_root_table[] = {


### PR DESCRIPTION
[22622.309938] sysctl table check failed: oaf/(null) procname is null
[22622.309965] sysctl table check failed: oaf/(null) No proc_handler
[22622.309970] init log sysctl...failed