### PR TITLE
luci-app-oaf: fix uci-defaults repeated execution

### DIFF
--- a/luci-app-oaf/root/etc/uci-defaults/94_feature_3.0
+++ b/luci-app-oaf/root/etc/uci-defaults/94_feature_3.0
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ "$(uci -q get appfilter.feature.format)" = "v3.0" ] && exit 0
+
 uci -q batch <<-EOF >/dev/null
         set appfilter.feature.format='v3.0'
         set appfilter.rule='rule'
@@ -9,3 +11,5 @@ uci -q batch <<-EOF >/dev/null
         set appfilter.global.auto_load_engine='1'
         commit appfilter
 EOF
+
+exit 0


### PR DESCRIPTION
软件包升级时，uci-defaults重新解压，将会再次执行。

避免重复执行时覆盖用户的配置。