### PR TITLE
luci-app-oaf: fix applist not update after submit empty applist

### DIFF
--- a/luci-app-oaf/luasrc/view/admin_network/app_filter.htm
+++ b/luci-app-oaf/luasrc/view/admin_network/app_filter.htm
@@ -192,7 +192,6 @@
             ]
         };
 		let app_filter_data = [];
-        const selectedAppIds = [1001, 1002, 1003];
 
 		function init_data2() {
 			// new XHR().get('<%=url('admin/network/class_list')%>', null,
@@ -216,8 +215,10 @@
 			return new Promise((resolve, reject) => {
 				new XHR().get('<%=url('admin/network/get_app_filter')%>', null,
 					function (x, data) {
-							if (Array.isArray(data.app_list))
-						app_filter_data = data.app_list;
+						if (Array.isArray(data.app_list))
+							app_filter_data = data.app_list;
+						else
+							app_filter_data = [];
 						resolve(); 
 					}
 				);


### PR DESCRIPTION
when array is empty, luci return an object instead of an empty array.

lua 的json序列化是有问题的，会将空数组序列化成一个object，前端应该当成空数组处理。