### PR TITLE
open-app-filter: ignore open /proc/sys/oaf/* failed

### DIFF
--- a/open-app-filter/src/appfilter_ubus.c
+++ b/open-app-filter/src/appfilter_ubus.c
@@ -1513,9 +1513,9 @@ static int handle_get_oaf_status(struct ubus_context *ctx, struct ubus_object *o
     int enable = 0;
     int ret = 0;
     int engine_status = 0;
-    
-    ret = exec_with_result_line("cat /proc/sys/oaf/enable", result, sizeof(result));
-    if (strlen(result) == 0){
+
+    ret = af_read_file_value("/proc/sys/oaf/enable", result, sizeof(result));
+    if (ret !=0 || strlen(result) == 0){
         engine_status = 0;
         enable = 0;
     }

--- a/open-app-filter/src/main.c
+++ b/open-app-filter/src/main.c
@@ -203,7 +203,8 @@ void update_oaf_proc_value(char *key, char *value){
     char old_value[128] = {0};
     sprintf(file_path, "/proc/sys/oaf/%s", key);
 
-    af_read_file_value(file_path, old_value, sizeof(old_value));    
+    if (af_read_file_value(file_path, old_value, sizeof(old_value)) == -1)
+        return;
     if (strcmp(old_value, value) != 0){
         sprintf(cmd_buf, "echo %s >/proc/sys/oaf/%s", value, key);
         system(cmd_buf);
@@ -349,25 +350,12 @@ void update_oaf_status(void){
     int cur_enable = 0;
     if(g_af_config.global.enable == 1){
 		ret = af_check_time(&g_af_config.time);
-		if (ret == 1){
-			system("echo 1 >/proc/sys/oaf/enable");
-		}
-		else{
-			system("echo 0 >/proc/sys/oaf/enable");
-		}
 	}
-	else{
-		system("echo 0 >/proc/sys/oaf/enable");
-	}
+    update_oaf_proc_value("enable", ret==1?"1":"0");
 }
 
 void update_oaf_record_status(void){
-    if(g_af_config.global.record_enable == 1){
-        system("echo 1 >/proc/sys/oaf/record_enable");
-    }
-    else{
-        system("echo 0 >/proc/sys/oaf/record_enable");
-    }
+    update_oaf_proc_value("record_enable", g_af_config.global.record_enable==1?"1":"0");
 }
 
 void af_hnat_init(void){

--- a/open-app-filter/src/main.c
+++ b/open-app-filter/src/main.c
@@ -467,7 +467,7 @@ void dev_list_timeout_handler(struct uloop_timeout *t)
     }
 
 
-    if (appfilter_nl_fd.fd < 0){
+    if (appfilter_nl_fd.fd < 0 && access("/proc/sys/oaf", F_OK) == 0){
         appfilter_nl_fd.fd = appfilter_nl_init();
         if (appfilter_nl_fd.fd > 0){
             uloop_fd_add(&appfilter_nl_fd, ULOOP_READ);

--- a/open-app-filter/src/utils.c
+++ b/open-app-filter/src/utils.c
@@ -73,14 +73,14 @@ int check_same_network(char *ip1, char *netmask, char *ip2) {
 int af_read_file_value(const char *file_path, char *value, int value_len) {
     FILE *file = fopen(file_path, "r");
     if (!file) {
-        perror("Failed to open file");
+        //perror("Failed to open file");
         return -1;
     }
 
     if (fgets(value, value_len, file) == NULL) {
         perror("Failed to read line from file");
         fclose(file);
-        return -1;
+        return -2;
     }
 
     size_t len = strlen(value);


### PR DESCRIPTION
kmod may not loaded

内核模块未加载的情况下，避免在系统日志打印“文件不存在”错误