### PR TITLE
open-app-filter: fix init script warning on built to openwrt firmware

### DIFF
--- a/open-app-filter/files/appfilter.init
+++ b/open-app-filter/files/appfilter.init
@@ -1,6 +1,4 @@
 #!/bin/sh /etc/rc.common
-. /usr/share/libubox/jshn.sh
-. /lib/functions.sh
 
 START=96
 USE_PROCD=1


### PR DESCRIPTION
修复集成到固件里时的警告：
```
./etc/init.d/appfilter: line 2: /usr/share/libubox/jshn.sh: No such file or directory                                                                                                                       
./etc/init.d/appfilter: line 3: /lib/functions.sh: No such file or directory  
```
而且这两个文件根本就没用上