### PR TITLE
luci-app-oaf: arrange app icons horizontally

### DIFF
--- a/luci-app-oaf/luasrc/view/admin_network/app_filter.htm
+++ b/luci-app-oaf/luasrc/view/admin_network/app_filter.htm
@@ -320,7 +320,7 @@
 
                     label.appendChild(containerDiv);
                     appItem.appendChild(label);
-                    appItemsRow.appendChild(appItem);
+                    appList.appendChild(appItem);
                 });
                 
                 appList.appendChild(appItemsRow);


### PR DESCRIPTION
增加全选功能后应用图标变成了竖直排列，改回横向排列。