### PR TITLE
luci-app-oaf: fix uci-defaults repeated execution

### DIFF
--- a/luci-app-oaf/root/etc/uci-defaults/94_feature_3.0
+++ b/luci-app-oaf/root/etc/uci-defaults/94_feature_3.0
@@ -9,6 +9,8 @@ uci -q batch <<-EOF >/dev/null
         set appfilter.global.tcp_rst='1'
         set appfilter.global.lan_ifname='br-lan'
         set appfilter.global.auto_load_engine='1'
+        del_list appfilter.time.time='00:00-23:59'
+        add_list appfilter.time.time='00:00-23:59'
         commit appfilter
 EOF
 


### PR DESCRIPTION
软件包升级时，uci-defaults重新解压，将会再次执行。

此时应避免覆盖用户的配置。